### PR TITLE
Update SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler (PDK Monitor)

### DIFF
--- a/PDKMonitor/SOI_220_nm_Passive/components/SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler/README.md
+++ b/PDKMonitor/SOI_220_nm_Passive/components/SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler/README.md
@@ -4,7 +4,7 @@ SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler — grating-coupler on SOI 2
 
 ---
 
-Prepared via CORNERSTONE PDK Monitor v1.0.0 on 2026-05-26T21:55:08.254Z.
+Prepared via CORNERSTONE PDK Monitor v1.0.0 on 2026-05-26T21:55:29.237Z.
 
 **Author identity:** https://github.com/AEmreKaplan/
 **BB type:** grating-coupler


### PR DESCRIPTION
Automated submission from CORNERSTONE PDK Monitor v1.0.0.

SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler — grating-coupler on SOI 220 nm Passive.

**BB type:** grating-coupler
**Category:** passive
**Platform:** SOI 220 nm Passive
**Status:** available
**Author identity:** https://github.com/AEmreKaplan/

## Files in this PR (5)

- `PDKMonitor/SOI_220_nm_Passive/components/SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler/SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler.gds`
- `PDKMonitor/SOI_220_nm_Passive/components/SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler/SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler.yaml`
- `PDKMonitor/SOI_220_nm_Passive/documents/SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler/SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler.yaml`
- `PDKMonitor/SOI_220_nm_Passive/s_matrix/SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler/SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler.csv`
- `PDKMonitor/SOI_220_nm_Passive/components/SOI220nm_1550nm_TE_RIB_EBL_Apodised_Grating_Coupler/README.md`

